### PR TITLE
[Issue #10] Ensure words do not shuffle in the original order

### DIFF
--- a/src/lib/utils/areArraysEqual.test.ts
+++ b/src/lib/utils/areArraysEqual.test.ts
@@ -10,7 +10,7 @@ describe('given arrays with the same elements', () => {
 });
 
 describe('given arrays with different elements', () => {
-	it('returns true', () => {
+	it('returns false', () => {
 		const arr1 = [1, 2, 3];
 		const arr2 = [1, 3, 3, 7];
 

--- a/src/lib/utils/areArraysEqual.test.ts
+++ b/src/lib/utils/areArraysEqual.test.ts
@@ -1,0 +1,37 @@
+import areArraysEqual from './areArraysEqual';
+
+describe('given arrays with the same elements', () => {
+	it('returns true', () => {
+		const arr1 = [1, 2, 3];
+		const arr2 = [1, 2, 3];
+
+		expect(areArraysEqual(arr1, arr2)).toBe(true);
+	});
+});
+
+describe('given arrays with different elements', () => {
+	it('returns true', () => {
+		const arr1 = [1, 2, 3];
+		const arr2 = [1, 3, 3, 7];
+
+		expect(areArraysEqual(arr1, arr2)).toBe(false);
+	});
+});
+
+describe('given arrays with different types of elements', () => {
+	it('returns true', () => {
+		const arr1 = [1, '2', 3];
+		const arr2 = [1, 2, 3];
+
+		expect(areArraysEqual(arr1, arr2)).toBe(false);
+	});
+});
+
+describe('given empty arrays', () => {
+	it('returns true', () => {
+		const arr1: unknown[] = [];
+		const arr2: unknown[] = [];
+
+		expect(areArraysEqual(arr1, arr2)).toBe(true);
+	});
+});

--- a/src/lib/utils/areArraysEqual.test.ts
+++ b/src/lib/utils/areArraysEqual.test.ts
@@ -19,7 +19,7 @@ describe('given arrays with different elements', () => {
 });
 
 describe('given arrays with different types of elements', () => {
-	it('returns true', () => {
+	it('returns false', () => {
 		const arr1 = [1, '2', 3];
 		const arr2 = [1, 2, 3];
 

--- a/src/lib/utils/areArraysEqual.ts
+++ b/src/lib/utils/areArraysEqual.ts
@@ -1,4 +1,4 @@
-const areArraysEqual = (a: any[], b: any[]) =>
+const areArraysEqual = (a: unknown[], b: unknown[]) =>
 	a.length === b.length && a.every((v, i) => v === b[i]);
 
 export default areArraysEqual;

--- a/src/lib/utils/areArraysEqual.ts
+++ b/src/lib/utils/areArraysEqual.ts
@@ -1,0 +1,4 @@
+const areArraysEqual = (a: any[], b: any[]) =>
+	a.length === b.length && a.every((v, i) => v === b[i]);
+
+export default areArraysEqual;

--- a/src/lib/utils/getRandomNumberGenerator.ts
+++ b/src/lib/utils/getRandomNumberGenerator.ts
@@ -1,0 +1,5 @@
+import Prando from 'prando';
+import { get } from 'svelte/store';
+import { gameProgress } from '$lib/store';
+
+export default new Prando(new Date().toDateString() + get(gameProgress));

--- a/src/lib/utils/shuffle.test.ts
+++ b/src/lib/utils/shuffle.test.ts
@@ -2,7 +2,7 @@ import { vi, type Mock } from 'vitest';
 import rng from './getRandomNumberGenerator';
 import getShuffledWord, { rearrangeLettersManually } from './shuffle';
 
-// TODO: I don't think we should have to mock these stores here.
+// TODO: Figure out how to not mock these store modules.
 vi.mock('svelte/store', () => ({ get: vi.fn() }));
 vi.mock('$lib/store', () => ({ gameProgress: 0 }));
 vi.mock('./getRandomNumberGenerator');

--- a/src/lib/utils/shuffle.test.ts
+++ b/src/lib/utils/shuffle.test.ts
@@ -1,0 +1,32 @@
+import { vi, type Mock } from 'vitest';
+import rng from './getRandomNumberGenerator';
+import getShuffledWord, { rearrangeLettersManually } from './shuffle';
+
+// TODO: I don't think we should have to mock these stores here.
+vi.mock('svelte/store', () => ({ get: vi.fn() }));
+vi.mock('$lib/store', () => ({ gameProgress: 0 }));
+vi.mock('./getRandomNumberGenerator');
+
+describe('getShuffledWord', () => {
+	const lettersStub = ['r', 'o', 'v', 'e'];
+
+	describe('when the letter shuffling results in no changes to the letter ordering', () => {
+		beforeEach(() => {
+			(rng.nextInt as Mock).mockReturnValueOnce(3).mockReturnValueOnce(2).mockReturnValueOnce(1);
+		});
+
+		it('returns the word manually shuffled', () => {
+			expect(getShuffledWord(lettersStub)).toEqual(rearrangeLettersManually(lettersStub));
+		});
+	});
+
+	describe('when the letter shuffling results changes to the letter ordering', () => {
+		beforeEach(() => {
+			(rng.nextInt as Mock).mockReturnValueOnce(1).mockReturnValueOnce(2).mockReturnValueOnce(0);
+		});
+
+		it('returns the shuffled letters', () => {
+			expect(getShuffledWord(lettersStub)).toEqual(['e', 'r', 'v', 'o']);
+		});
+	});
+});

--- a/src/lib/utils/shuffle.ts
+++ b/src/lib/utils/shuffle.ts
@@ -1,14 +1,32 @@
-import Prando from 'prando';
-import { get } from 'svelte/store';
-import { gameProgress } from '$lib/store';
+import areArraysEqual from './areArraysEqual';
+import rng from './getRandomNumberGenerator';
 
-export default (array: string[]) => {
-	const today = new Date();
-	const rng = new Prando(today.toDateString() + get(gameProgress));
-	for (let i = array.length - 1; i > 0; i--) {
-		const j = rng.nextInt(0, i + 1);
-		[array[i], array[j]] = [array[j], array[i]];
+export const getShuffledWord = (letters: string[]): string[] => {
+	const rearrangedWord = rearrangeLettersWithRng(letters);
+
+	const isShuffledWordUnchanged = areArraysEqual(letters, rearrangedWord);
+	if (isShuffledWordUnchanged) return rearrangeLettersManually(letters);
+
+	return rearrangedWord;
+};
+
+const rearrangeLettersWithRng = (letters: string[]) => {
+	const newLetters = [...letters];
+
+	for (let i = newLetters.length - 1; i > 0; i--) {
+		const j = rng.nextInt(0, i);
+
+		[newLetters[i], newLetters[j]] = [newLetters[j], newLetters[i]];
 	}
 
-	return array;
+	return newLetters;
 };
+
+export const rearrangeLettersManually = (letters: string[]) => [
+	letters[2],
+	letters[0],
+	letters[3],
+	letters[1]
+];
+
+export default getShuffledWord;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"strictNullChecks": true
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//


### PR DESCRIPTION
Implementation of #10 

## TL;DR 
If a word gets shuffled into its original order, just shuffle it manually.

## Long Version
- Implement and test a util function for checking if arrays are equal. This is used for checking if the shuffled letters are in the original order.
- Break up the shuffle module into a few smaller functions. The default export's logic is now a wrapper for the original shuffling behavior. However, it does the checking of the order of the word shuffling.
- Extract getting a random number generator to an injector. This enables us to mock what the rng will produce, and thus reproduce the conditions in which the order is unchanged.

### Miscellaneous
I also enabled strict null checks, because it occurred to me that this codebase did not already have it on.