### PR TITLE
No more duplicate words unless absolutely necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordchain",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/src/lib/assets/changelog.ts
+++ b/src/lib/assets/changelog.ts
@@ -1,5 +1,9 @@
 export const changelog = [
 	{
+		version: '0.8.0',
+		changes: ['No more duplicate words 🐧', 'New words added.']
+	},
+	{
 		version: '0.7.0',
 		changes: ['Improved word shuffling.', 'New words added.']
 	},

--- a/src/lib/utils/wordUtils.test.ts
+++ b/src/lib/utils/wordUtils.test.ts
@@ -16,20 +16,14 @@ describe('checkIfValidWord', () => {
 
 describe('generateWord', () => {
 	it('returns a word having 5 letters', () => {
-		const word = generateWord(1);
+		const word = generateWord();
 
 		expect(word.length).toBe(5);
 	});
 
 	describe('given a specific first letter', () => {
-		it('returns a word having 5 letters', () => {
-			const word = generateWord(1, 'h');
-
-			expect(word.length).toBe(5);
-		});
-
 		it('returns a word with the same first letter as requested', () => {
-			const word = generateWord(1, 'h');
+			const word = generateWord(['youth']);
 
 			expect(word[0]).toBe('h');
 		});
@@ -37,8 +31,8 @@ describe('generateWord', () => {
 
 	describe('when invoked with the same seed', () => {
 		it('generates the same word each time', () => {
-			const word = generateWord(42);
-			const word2 = generateWord(42);
+			const word = generateWord(['woven', 'neigh', 'hello']);
+			const word2 = generateWord(['woven', 'neigh', 'hello']);
 
 			expect(word).toBe(word2);
 		});
@@ -46,17 +40,25 @@ describe('generateWord', () => {
 
 	describe('when invoked with different seeds', () => {
 		it('generates the same word each time', () => {
-			const word = generateWord(17);
-			const word2 = generateWord(38);
+			const word = generateWord(['woven', 'neigh', 'hello']);
+			const word2 = generateWord(['neigh', 'hello']);
 
 			expect(word).not.toBe(word2);
 		});
 	});
 
 	// Issue #17
-	describe('when invoked with x as the first letter', () => {
+	describe('when invoked with x as the desired first letter', () => {
 		it('generates a word that starts with x', () => {
-			const word = generateWord(1, 'x');
+			const word = generateWord(['relax']);
+
+			expect(word[0]).toBe('x');
+		});
+	});
+
+	describe('when invoked with solved words already having xenon', () => {
+		it('generates a word that starts with x', () => {
+			const word = generateWord(['relax', 'xenon', 'nimph', 'helix']);
 
 			expect(word[0]).toBe('x');
 		});

--- a/src/lib/utils/wordUtils.ts
+++ b/src/lib/utils/wordUtils.ts
@@ -1,17 +1,31 @@
-import { dictionary } from '$lib/assets/dictionary';
 import Prando from 'prando';
+import { dictionary } from '$lib/assets/dictionary';
 
 export const checkIfValidWord = (word: string) => {
 	return dictionary.includes(word.toLowerCase());
 };
 
-export const generateWord = (solvedWords: number, firstLetter = ''): string => {
+export const generateWord = (solvedWords: string[] = []): string => {
 	const date = new Date();
-	const rng = new Prando(date.getDay().toString() + ' ' + solvedWords);
+	const seed =
+		date.getFullYear() +
+		date.getMonth() * 10000 +
+		date.getDate() * 1000000 +
+		(solvedWords.length + 1) * 100000000;
+	const rng = new Prando(seed);
 
-	// If the generated word needs to have a specific first letter.
-	if (firstLetter.length > 0) {
+	// If the word to generate needs to have a specific first letter.
+	if (solvedWords.length > 0) {
+		const firstLetter = solvedWords[solvedWords.length - 1].at(-1);
 		const wordsWithFirstLetter = dictionary.filter((word) => word[0] == firstLetter);
+		const solvedWordsRemoved = wordsWithFirstLetter.filter((word) => !solvedWords.includes(word));
+
+		if (solvedWordsRemoved.length > 0) {
+			const randomIndex = rng.nextInt(0, solvedWordsRemoved.length - 1);
+			return solvedWordsRemoved[randomIndex];
+		}
+
+		// All words with the same first letter have been solved, just pick a random word that starts with firstLetter.
 		const randomIndex = rng.nextInt(0, wordsWithFirstLetter.length - 1);
 		return wordsWithFirstLetter[randomIndex];
 	} else {

--- a/src/routes/play/+page.svelte
+++ b/src/routes/play/+page.svelte
@@ -11,8 +11,9 @@
 	gameProgress.set(0);
 
 	const wordsToSolve = 7;
+	let solvedWords: string[] = [];
 
-	let wordToGuess: string = generateWord($gameProgress);
+	let wordToGuess: string = generateWord(solvedWords);
 	let playedLetters: LetterData[] = createLetterData([wordToGuess[0]], true);
 	let unplayedLetters: LetterData[];
 
@@ -74,7 +75,8 @@
 		if (checkIfValidWord(wordToCheck)) {
 			playedLetters = makeWordUsed(playedLetters, wordToCheck);
 			gameProgress.update((progress) => progress + 1);
-			wordToGuess = generateWord($gameProgress, playedLetters[playedLetters.length - 1].value);
+			solvedWords.push(wordToCheck);
+			wordToGuess = generateWord(solvedWords);
 
 			gameComplete = $gameProgress == wordsToSolve;
 		} else {


### PR DESCRIPTION
`generateWord()` now just takes in the list of solved words as an optional parameter. This removes the need for the number of solved words, as well as the first letter needed for word generation.

The function will attempt to generate a word that wasn't included in `solvedWords`. If it cant, it will just pick one like it used to.